### PR TITLE
fixed typo in [util/ai.ts]

### DIFF
--- a/util/ai.ts
+++ b/util/ai.ts
@@ -26,7 +26,7 @@ const parser = StructuredOutputParser.fromZodSchema(
     color: z
       .string()
       .describe(
-        'a hexidecimal color code the represents the mood of the entry. Example #0101fe for blue representing happiness.'
+        'a hexidecimal color code that represents the mood of the entry. Example #0101fe for blue representing happiness.'
       ),
     sentimentScore: z
       .number()


### PR DESCRIPTION
Corrected a minor grammatical error in the description of the hexidecimal color code. 

Changed:
"a hexidecimal color code the represents the mood..."
To:
"a hexidecimal color code that represents the mood..."
