### PR TITLE
"Fixing prisma problem when pushing to planet scale"

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -64,7 +64,7 @@ model EntryAnalysis {
   subject String @db.Text
   negative Boolean
   summary String @db.Text
-  color String @db.Text @default("#0101fe")
+  color String @default("#0101fe")
   sentimentScore Float
 
   @@unique([entryId])


### PR DESCRIPTION
I got this error when using the command `npx prisma db push`

**Error Message**:

Error: target: mood.-.primary: vttablet: rpc error: code = InvalidArgument desc = BLOB, TEXT, GEOMETRY or JSON column 'color' can't have a default value (errno 1101) (sqlstate 42000) (CallerID: planetscale-admin): Sql: "create table EntryAnalysis (\n\tid VARCHAR(191) not null,\n\tcreatedAt DATETIME(3) not null default current_timestamp(3),\n\tupdatedAt DATETIME(3) not null,\n\tentryId VARCHAR(191) not null,\n\tuserId VARCHAR(191) not null,\n\tmood TEXT not null,\n\tsubject TEXT not null,\n\tnegative BOOLEAN not null,\n\tsummary TEXT not null,\n\tcolor TEXT not null default '#0101fe',\n\tsentimentScore DOUBLE not null,\n\tkey EntryAnalysis_userId_idx (userId),\n\tunique key EntryAnalysis_entryId_key (entryId),\n\tprimary key (id)\n) charset utf8mb4,\n  COLLATE utf8mb4_unicode_ci", BindVars: {REDACTED}
   0: sql_schema_connector::apply_migration::migration_step
           with step=CreateTable { table_id: TableId(3) }
             at schema-engine\connectors\sql-schema-connector\src\apply_migration.rs:21
   1: sql_schema_connector::apply_migration::apply_migration
             at schema-engine\connectors\sql-schema-connector\src\apply_migration.rs:10
   2: schema_core::state::SchemaPush
             at schema-engine\core\src\state.rs:436


**Error Explanation**:

The error you're encountering is due to a limitation in MySQL and, by extension, PlanetScale. MySQL does not allow BLOB, TEXT, GEOMETRY, or JSON data types to have a default value, which is what's causing the error in your Prisma schema. In your EntryAnalysis model, the color field is of type String @db.Text and has a default value of '#0101fe'. This is not allowed in MySQL.

To fix this problem
I removed @db.Text